### PR TITLE
feat(frontend): add Apollo configuration and remove unused GraphQL queries

### DIFF
--- a/frontend/apollo.config.js
+++ b/frontend/apollo.config.js
@@ -1,0 +1,11 @@
+/* eslint-env node */
+module.exports = {
+  client: {
+    service: {
+      name: 'codefox-backend1',
+      localSchemaFile: './src/graphql/schema.gql',
+    },
+    includes: ['./src/**/*.{js,ts,tsx}'],
+    excludes: ['**/__tests__/**'],
+  },
+};

--- a/frontend/src/components/file-sidebar.tsx
+++ b/frontend/src/components/file-sidebar.tsx
@@ -7,7 +7,6 @@ import { SquarePen } from 'lucide-react';
 import SidebarSkeleton from './sidebar-skeleton';
 import UserSettings from './user-settings';
 import { SideBarItem } from './sidebar-item';
-import { Chat } from '@/graphql/type';
 import { EventEnum } from '../const/EventEnum';
 import {
   SidebarContent,

--- a/frontend/src/graphql/request.ts
+++ b/frontend/src/graphql/request.ts
@@ -28,17 +28,6 @@ export const CREATE_CHAT = gql`
   }
 `;
 
-export const SAVE_CHAT_HISTORY = gql`
-  mutation SaveChatHistory($chatId: String!, $messages: [MessageInput!]!) {
-    saveChatHistory(chatId: $chatId, messages: $messages) {
-      id
-      content
-      role
-      createdAt
-    }
-  }
-`;
-
 export const GET_CHAT_HISTORY = gql`
   query GetChatHistory($chatId: String!) {
     getChatHistory(chatId: $chatId) {
@@ -138,20 +127,6 @@ export const GET_USER_PROJECTS = gql`
   }
 `;
 
-export const GET_PROJECT_DETAILS = gql`
-  query GetProjectDetails($projectId: String!) {
-    getProjectDetails(projectId: $projectId) {
-      id
-      projectName
-      path
-      projectPackages {
-        id
-        content
-      }
-    }
-  }
-`;
-
 export const CREATE_PROJECT = gql`
   mutation CreateProject($createProjectInput: CreateProjectInput!) {
     createProject(createProjectInput: $createProjectInput) {
@@ -166,26 +141,4 @@ export const CREATE_PROJECT = gql`
 export const getUserProjects = async (client: ApolloClient<unknown>) => {
   const response = await client.query({ query: GET_USER_PROJECTS });
   return response.data.getUserProjects;
-};
-
-export const getProjectDetails = async (
-  client: ApolloClient<unknown>,
-  projectId: string
-) => {
-  const response = await client.query({
-    query: GET_PROJECT_DETAILS,
-    variables: { projectId },
-  });
-  return response.data.getProjectDetails;
-};
-
-export const createProject = async (
-  client: ApolloClient<unknown>,
-  createProjectInput: any
-) => {
-  const response = await client.mutate({
-    mutation: CREATE_PROJECT,
-    variables: { createProjectInput },
-  });
-  return response.data.createProject;
 };


### PR DESCRIPTION
This Pull Request adds Apollo GraphQL configuration and removes unused GraphQL queries. By integrating Apollo, developers can now benefit from Language Server Protocol (LSP) support directly in VSCode by installing the Apollo GraphQL extension. This provides enhanced features like autocompletion, validation, and schema awareness when working with GraphQL queries, making development more efficient and reducing errors.
![image](https://github.com/user-attachments/assets/f4624187-0c4c-4d3f-9d26-f5027d486181)
