### PR TITLE
chore(frontend): prevent loading chat detail again if didn't change the chatId

### DIFF
--- a/frontend/src/components/chat/index.tsx
+++ b/frontend/src/components/chat/index.tsx
@@ -77,9 +77,12 @@ export default function Chat() {
 
   // Effect to initialize chat ID and refresh the chat list based on URL parameters
   useEffect(() => {
-    setChatId(urlParams.get('id') || '');
-    refetchChats();
-  }, [urlParams, refetchChats]);
+    const newChatId = urlParams.get('id') || '';
+    if (newChatId !== chatId) {
+      setChatId(newChatId);
+      refetchChats();
+    }
+  }, [urlParams, chatId, refetchChats]);
 
   // Effect to add and remove global event listeners
   useEffect(() => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Optimized chat behavior so that the conversation refreshes only when a different chat is selected, enhancing performance and user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->